### PR TITLE
MPDP-678 Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           path: ./changelog
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          force: true
 
       - name: SonarQube Cloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Create Test Coverage Reports
         run: |
           npm ci
-          npm run build
           npm test
 
       - name: Publish Database Schema


### PR DESCRIPTION
PR is part of the implementation of https://eaflood.atlassian.net/browse/MPDP-678

[Error on publish workflow](https://github.com/DEFRA/fcp-mpdp-backend/actions/runs/16295556220/job/46016108699) after merging to PR #2 to `main` at `npm run build` stage as there is no `build` script provided in the `package.json`. This PR removes that step to avoid failing build.
