### PR TITLE
Set Liquibase image version to v4

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -32,7 +32,7 @@ services:
       timeout: 10s
 
   liquibase:
-    image: liquibase/liquibase
+    image: liquibase/liquibase:4
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Liquibase v5 introduces [major breaking changes](https://docs.liquibase.com/community/release-notes/5-0) which causes the backend database to properly start up and run the changelogs. This PR sets the Liquibase image version to v4 to avoid this in future and to support local development.
