### PR TITLE
Replace Snyk with Dependency Review and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -11,6 +11,9 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  contents: read
+
 jobs:
   pr-validator:
     name: Run Pull Request Checks
@@ -38,9 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-      - name: Snyk Scan
-        uses: snyk/actions/node@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
         with:
-          args: --severity-threshold=medium
+          fail-on-severity: moderate

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-mpdp-backend&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-mpdp-backend)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-mpdp-backend&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-mpdp-backend)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-mpdp-backend&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-mpdp-backend)
+[![Dependabot](https://badgen.net/github/dependabot/DEFRA/fcp-mpdp-backend)](https://github.com/DEFRA/fcp-mpdp-backend/security/dependabot)
 
 # fcp-mpdp-backend
 


### PR DESCRIPTION
## Changes

- **Replaced Snyk** with `actions/dependency-review-action@v4` (fails on `moderate` severity) in `check-pull-request.yml`
- **Added `permissions: contents: read`** to the workflow (required by the dependency review action)
- **Created `.github/dependabot.yml`** enabling daily checks for npm and Docker
- **Added Dependabot badge** to README