### PR TITLE
Refactor number references

### DIFF
--- a/src/data/filters.js
+++ b/src/data/filters.js
@@ -51,7 +51,7 @@ function groupByPayee (searchResults) {
       acc.push({ ...item })
     } else {
       payee.total_amount =
-        parseFloat(payee.total_amount) + parseFloat(item.total_amount)
+        Number.parseFloat(payee.total_amount) + Number.parseFloat(item.total_amount)
     }
 
     return acc
@@ -66,12 +66,12 @@ function filterByAmounts (searchResults, amounts) {
   }
   const amountRanges = amounts.map((range) => {
     const [from, to] = range.split('-')
-    return { from: parseFloat(from), to: parseFloat(to) }
+    return { from: Number.parseFloat(from), to: Number.parseFloat(to) }
   })
 
   return searchResults.filter((result) => {
     return amountRanges.some((range) => {
-      const totalAmount = parseFloat(result.total_amount)
+      const totalAmount = Number.parseFloat(result.total_amount)
       return !range.to
         ? totalAmount >= range.from
         : totalAmount >= range.from && totalAmount <= range.to

--- a/src/data/payments.js
+++ b/src/data/payments.js
@@ -86,9 +86,9 @@ function getAllPaymentsCsvStream () {
 }
 
 function getReadableAmount (amount) {
-  const floatAmount = parseFloat(amount)
+  const floatAmount = Number.parseFloat(amount)
 
-  if (isNaN(floatAmount)) {
+  if (Number.isNaN(floatAmount)) {
     return '0.00'
   }
 


### PR DESCRIPTION
Replace bare `parseFloat` / `isNaN` calls with `Number.parseFloat` / `Number.isNaN` for consistency with the ESLint preference for module-scoped number methods.\n\n### Changes\n- `src/data/filters.js` — 4 occurrences of `parseFloat`\n- `src/data/payments.js` — `parseFloat` and `isNaN`