### PR TITLE
Patch vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,12 +35,12 @@
         "undici": "7.28.0"
       },
       "devDependencies": {
-        "@testcontainers/postgresql": "10.27.0",
+        "@testcontainers/postgresql": "12.0.3",
         "@vitest/coverage-v8": "4.1.4",
         "cross-env": "7.0.3",
         "eslint": "9.29.0",
         "neostandard": "0.12.1",
-        "testcontainers": "10.27.0",
+        "testcontainers": "12.0.3",
         "vitest": "4.1.4"
       },
       "engines": {
@@ -1228,16 +1228,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
@@ -1872,6 +1862,16 @@
       "dependencies": {
         "@json2csv/formatters": "^7.0.6",
         "@streamparser/json": "^0.0.20"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2932,13 +2932,13 @@
       }
     },
     "node_modules/@testcontainers/postgresql": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-10.27.0.tgz",
-      "integrity": "sha512-xJMhH68GVl1wE+FifIgKElZqArBeagat4qFh0etN/bvR3FC0mdHWKkzzAToNficSNXxutN5UarYlSSt0YLMMbQ==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-12.0.3.tgz",
+      "integrity": "sha512-y0l/ItWxNfdMU783EOZ66lMq90uuuXPqE+fo1jNSRfMbtfUq/9Ez/wluDxxaS+D/i3I0juep+jmz/WVuip8i9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "testcontainers": "^10.27.0"
+        "testcontainers": "^12.0.3"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2991,9 +2991,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.47",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.47.tgz",
-      "integrity": "sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4966,9 +4966,9 @@
       "license": "MIT"
     },
     "node_modules/docker-compose": {
-      "version": "0.24.8",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
-      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
+      "integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5010,9 +5010,9 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
-      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.0.tgz",
+      "integrity": "sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5021,11 +5021,10 @@
         "@grpc/proto-loader": "^0.7.13",
         "docker-modem": "^5.0.7",
         "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4",
-        "uuid": "^10.0.0"
+        "tar-fs": "^2.1.4"
       },
       "engines": {
-        "node": ">= 8.0"
+        "node": ">= 14.17"
       }
     },
     "node_modules/dockerode/node_modules/readable-stream": {
@@ -5071,21 +5070,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/dockerode/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/doctrine": {
@@ -7815,16 +7799,19 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -8684,16 +8671,17 @@
       "license": "ISC"
     },
     "node_modules/properties-reader": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.3.0.tgz",
-      "integrity": "sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mkdirp": "^1.0.4"
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
@@ -9844,40 +9832,37 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.27.0.tgz",
-      "integrity": "sha512-Y1A2OerjRKUDZ00tAbn1hHHHVeEH+jRgg7a41AF6mLUZPlBIkL8stSQkEzziFp1IK3Id9hPKu7Iq7rIpavkYaw==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-12.0.3.tgz",
+      "integrity": "sha512-6vfiL9CWIX0rWhTJitzrzHcv4Q/sUfUdBV12jMz6HZ58Lz6ZtXVecO6jljd1O3ookEWQHNICiYoYNEPpDLzuRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "@types/dockerode": "^3.3.35",
+        "@types/dockerode": "^4.0.1",
         "archiver": "^7.0.1",
         "async-lock": "^1.4.1",
         "byline": "^5.0.0",
-        "debug": "^4.3.5",
-        "docker-compose": "^0.24.8",
-        "dockerode": "^4.0.5",
-        "get-port": "^7.1.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.4.2",
+        "dockerode": "^5.0.0",
+        "get-port": "^7.2.0",
         "proper-lockfile": "^4.1.2",
-        "properties-reader": "^2.3.0",
+        "properties-reader": "^3.0.1",
         "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.0.7",
-        "tmp": "^0.2.3",
-        "undici": "^5.29.0"
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.7",
+        "undici": "^8.3.0"
       }
     },
     "node_modules/testcontainers/node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/text-decoder": {

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
     "undici": "7.28.0"
   },
   "devDependencies": {
-    "@testcontainers/postgresql": "10.27.0",
+    "@testcontainers/postgresql": "12.0.3",
     "@vitest/coverage-v8": "4.1.4",
     "cross-env": "7.0.3",
     "eslint": "9.29.0",
     "neostandard": "0.12.1",
-    "testcontainers": "10.27.0",
+    "testcontainers": "12.0.3",
     "vitest": "4.1.4"
   }
 }


### PR DESCRIPTION
## Changes

Upgrade `testcontainers` and `@testcontainers/postgresql` from `10.27.0` to `12.0.4` to resolve high and moderate severity vulnerabilities.

## Vulnerabilities addressed

- **[GHSA-g9mf-h72j-4rw9]** Undici unbounded decompression chain — high
- **[GHSA-2mjp-6q6p-2qxm]** Undici HTTP request/response smuggling — high
- **[GHSA-vrm6-8vpv-qv8q]** Undici unbounded memory in WebSocket — moderate
- **[GHSA-v9p9-hfj2-hcw8]** Undici WebSocket unhandled exception — moderate
- **[GHSA-4992-7rv2-5pvq]** Undici CRLF injection — moderate
- **[GHSA-p88m-4jfj-68fv]** Undici HTTP header injection via Set-Cookie — moderate
- **[GHSA-vxpw-j846-p89q]** Undici WebSocket DoS via fragment count bypass — moderate
- **[GHSA-35p6-xmwp-9g52]** Undici HTTP response queue poisoning — moderate
- **[GHSA-g8m3-5g58-fq7m]** Undici Set-Cookie SameSite downgrade — moderate

## Breaking changes in testcontainers v12

Two breaking changes in v12.0.0 — neither affects this codebase:

1. **Node.js minimum `>=22.22`** — this service requires `>=24.0.0`, satisfied.
2. **Default wait strategy changed** (uses Docker healthcheck when available, falls back to `Wait.forListeningPorts()`) — all containers in `test/setup/global-db.js` use explicit wait strategies (`Wait.forOneShotStartup()`, `PostgreSqlContainer` built-in), so unaffected.

## Remaining vulnerabilities

2 moderate vulnerabilities remain in `sequelize@6.37.8` (a direct dependency) via its internal `uuid@^8.3.2`. The npm-suggested fix (`sequelize@3.30.0`) is a broken advisory — it would downgrade to a 10-year-old version. `sequelize@6.37.8` is the latest stable v6 and the sequelize project has not yet updated its uuid dependency. This is tracked upstream.