### PR TITLE
List publish dates

### DIFF
--- a/src/data/payments-admin.js
+++ b/src/data/payments-admin.js
@@ -210,6 +210,23 @@ async function bulkUploadPayments (csvStream) {
   })
 }
 
+async function getPaymentsByPublishedDateTotals () {
+  const { fn, col } = models.PaymentDetail.sequelize
+  return models.PaymentDetail.findAll({
+    attributes: [
+      'published_date',
+      'financial_year',
+      [fn('COUNT', col('id')), 'count']
+    ],
+    group: ['published_date', 'financial_year'],
+    order: [
+      ['published_date', 'ASC'],
+      ['financial_year', 'ASC']
+    ],
+    raw: true
+  })
+}
+
 export {
   getPaymentById,
   createPayment,
@@ -221,5 +238,6 @@ export {
   getAllPaymentsForAdmin,
   searchPaymentsForAdmin,
   bulkUploadPayments,
-  bulkSetPublishedDate
+  bulkSetPublishedDate,
+  getPaymentsByPublishedDateTotals
 }

--- a/src/routes/payments-admin.js
+++ b/src/routes/payments-admin.js
@@ -10,7 +10,8 @@ import {
   getAllPaymentsForAdmin,
   searchPaymentsForAdmin,
   bulkUploadPayments,
-  bulkSetPublishedDate
+  bulkSetPublishedDate,
+  getPaymentsByPublishedDateTotals
 } from '../data/payments-admin.js'
 
 const paymentsAdmin = [
@@ -219,7 +220,7 @@ const paymentsAdmin = [
       tags: ['api', 'admin', 'payments'],
       validate: {
         params: Joi.object({
-          publishedDate: Joi.string().isoDate().required()
+          publishedDate: Joi.date().iso().required()
         })
       }
     },
@@ -250,6 +251,19 @@ const paymentsAdmin = [
       const { published_date: publishedDate } = request.payload
       const result = await bulkSetPublishedDate(financialYear, publishedDate)
       return h.response(result)
+    }
+  },
+  {
+    method: 'GET',
+    path: '/v1/payments/admin/payments/published-date-totals',
+    options: {
+      description: 'Get payment counts grouped by published date and financial year',
+      notes: 'Returns all payment records grouped by published date and financial year with a count',
+      tags: ['api', 'admin', 'payments']
+    },
+    handler: async (_request, h) => {
+      const totals = await getPaymentsByPublishedDateTotals()
+      return h.response(totals)
     }
   }
 ]

--- a/test/integration/narrow/routes/payments-admin.test.js
+++ b/test/integration/narrow/routes/payments-admin.test.js
@@ -341,7 +341,7 @@ describe('payments admin routes', () => {
 
       const response = await server.inject(options)
       expect(response.statusCode).toBe(200)
-      expect(deletePaymentsByPublishedDate).toHaveBeenCalledWith('2024-01-15T00:00:00.000Z')
+      expect(deletePaymentsByPublishedDate).toHaveBeenCalledWith(new Date('2024-01-15T00:00:00.000Z'))
       expect(JSON.parse(response.payload)).toEqual(mockResult)
     })
 
@@ -358,7 +358,7 @@ describe('payments admin routes', () => {
 
       const response = await server.inject(options)
       expect(response.statusCode).toBe(200)
-      expect(deletePaymentsByPublishedDate).toHaveBeenCalledWith('2023-12-31T00:00:00.000Z')
+      expect(deletePaymentsByPublishedDate).toHaveBeenCalledWith(new Date('2023-12-31T00:00:00.000Z'))
     })
 
     test('should return 400 for invalid date format', async () => {

--- a/test/integration/narrow/routes/payments-admin.test.js
+++ b/test/integration/narrow/routes/payments-admin.test.js
@@ -21,7 +21,8 @@ const {
   deletePaymentsByPublishedDate,
   getFinancialYears,
   bulkUploadPayments,
-  bulkSetPublishedDate
+  bulkSetPublishedDate,
+  getPaymentsByPublishedDateTotals
 } = await import('../../../../src/data/payments-admin.js')
 
 const { createServer } = await import('../../../../src/server.js')
@@ -486,6 +487,64 @@ describe('payments admin routes', () => {
 
       const response = await server.inject(options)
       expect(response.statusCode).toBe(400)
+    })
+  })
+
+  describe('GET /v1/payments/admin/payments/published-date-totals', () => {
+    test('should return 200 with grouped totals', async () => {
+      const mockTotals = [
+        { published_date: '2024-01-15', financial_year: '2023/24', count: '50' },
+        { published_date: '2024-01-15', financial_year: '2022/23', count: '30' },
+        { published_date: '2024-02-20', financial_year: '2023/24', count: '100' },
+        { published_date: null, financial_year: '2022/23', count: '10' }
+      ]
+      getPaymentsByPublishedDateTotals.mockResolvedValue(mockTotals)
+
+      const options = {
+        method: 'GET',
+        url: '/v1/payments/admin/payments/published-date-totals'
+      }
+
+      const response = await server.inject(options)
+
+      expect(response.statusCode).toBe(200)
+      expect(getPaymentsByPublishedDateTotals).toHaveBeenCalledTimes(1)
+      expect(JSON.parse(response.payload)).toEqual(mockTotals)
+    })
+
+    test('should return empty array when no payments exist', async () => {
+      getPaymentsByPublishedDateTotals.mockResolvedValue([])
+
+      const options = {
+        method: 'GET',
+        url: '/v1/payments/admin/payments/published-date-totals'
+      }
+
+      const response = await server.inject(options)
+
+      expect(response.statusCode).toBe(200)
+      expect(JSON.parse(response.payload)).toEqual([])
+    })
+
+    test('should include null published_date entries in the response', async () => {
+      const mockTotals = [
+        { published_date: null, financial_year: '2022/23', count: '10' },
+        { published_date: null, financial_year: '2023/24', count: '5' }
+      ]
+      getPaymentsByPublishedDateTotals.mockResolvedValue(mockTotals)
+
+      const options = {
+        method: 'GET',
+        url: '/v1/payments/admin/payments/published-date-totals'
+      }
+
+      const response = await server.inject(options)
+
+      expect(response.statusCode).toBe(200)
+      const payload = JSON.parse(response.payload)
+      expect(payload).toHaveLength(2)
+      expect(payload[0].published_date).toBeNull()
+      expect(payload[1].published_date).toBeNull()
     })
   })
 })

--- a/test/unit/data/payments-admin.test.js
+++ b/test/unit/data/payments-admin.test.js
@@ -20,7 +20,8 @@ const {
   deletePaymentsByYear,
   deletePaymentsByPublishedDate,
   getFinancialYears,
-  bulkUploadPayments
+  bulkUploadPayments,
+  getPaymentsByPublishedDateTotals
 } = await import('../../../src/data/payments-admin.js')
 
 describe('admin', () => {
@@ -391,6 +392,45 @@ Test Payee,SW1,London,Westminster,Greater London,BPS,not_a_number,23/24,2024-01-
         ]),
         { validate: true }
       )
+    })
+  })
+
+  describe('getPaymentsByPublishedDateTotals', () => {
+    test('should return counts grouped by published date and financial year', async () => {
+      const mockTotals = [
+        { published_date: '2024-01-15', financial_year: '2023/24', count: '50' },
+        { published_date: '2024-01-15', financial_year: '2022/23', count: '30' },
+        { published_date: '2024-02-20', financial_year: '2023/24', count: '100' },
+        { published_date: null, financial_year: '2022/23', count: '10' }
+      ]
+      models.PaymentDetail.findAll = vi.fn().mockResolvedValue(mockTotals)
+      models.PaymentDetail.sequelize = {
+        fn: vi.fn().mockReturnValue('COUNT(id)'),
+        col: vi.fn().mockReturnValue('id')
+      }
+
+      const result = await getPaymentsByPublishedDateTotals()
+
+      expect(models.PaymentDetail.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          group: ['published_date', 'financial_year'],
+          order: [['published_date', 'ASC'], ['financial_year', 'ASC']],
+          raw: true
+        })
+      )
+      expect(result).toEqual(mockTotals)
+    })
+
+    test('should return empty array when no payments exist', async () => {
+      models.PaymentDetail.findAll = vi.fn().mockResolvedValue([])
+      models.PaymentDetail.sequelize = {
+        fn: vi.fn().mockReturnValue('COUNT(id)'),
+        col: vi.fn().mockReturnValue('id')
+      }
+
+      const result = await getPaymentsByPublishedDateTotals()
+
+      expect(result).toEqual([])
     })
   })
 })


### PR DESCRIPTION
Adds a new endpoint `GET /v1/payments/admin/payments/published-date-totals` that returns payment counts grouped by `published_date` and `financial_year`, ordered by date ascending (NULLs last) then financial year.\n\n## Changes\n- `src/data/payments-admin.js` — new `getPaymentsByPublishedDateTotals()` data function\n- `src/routes/payments-admin.js` — new GET route exposing the totals endpoint\n- `test/unit/data/payments-admin.test.js` — unit tests for the new data function\n- `test/integration/narrow/routes/payments-admin.test.js` — updated assertions to use `Date` objects