### PR TITLE
Address Sonar issues

### DIFF
--- a/src/common/helpers/secure-context/index.js
+++ b/src/common/helpers/secure-context/index.js
@@ -1,2 +1,1 @@
-import { secureContext } from './secure-context.js'
-export { secureContext }
+export { secureContext } from './secure-context.js'

--- a/src/data/payments.js
+++ b/src/data/payments.js
@@ -1,4 +1,4 @@
-import { Readable } from 'stream'
+import { Readable } from 'node:stream'
 import { AsyncParser } from '@json2csv/node'
 import { getAllPaymentsByPage } from './database.js'
 import { getPaymentData } from './search.js'

--- a/test/integration/narrow/data/search.test.js
+++ b/test/integration/narrow/data/search.test.js
@@ -82,18 +82,18 @@ describe('search', () => {
 
     test('should not offset results if action is download', async () => {
       const data = await getPaymentData({ searchString: 'payee name', limit: 1, offset: 1, sortBy: 'score', filterBy: {}, action: 'download' })
-      expect(data.rows.length).toBe(3)
+      expect(data.rows).toHaveLength(3)
     })
 
     test('should paginate results if action is not download', async () => {
       const data = await getPaymentData({ searchString: 'payee name', limit: 1, offset: 0, sortBy: 'score', filterBy: {} })
-      expect(data.rows.length).toBe(1)
+      expect(data.rows).toHaveLength(1)
       expect(data.rows[0].payee_name).toBe('payee name 1')
     })
 
     test('should offset results if action is not download and offset is greater than 0', async () => {
       const data = await getPaymentData({ searchString: 'payee name', limit: 1, offset: 1, sortBy: 'score', filterBy: {} })
-      expect(data.rows.length).toBe(1)
+      expect(data.rows).toHaveLength(1)
       expect(data.rows[0].payee_name).toBe('payee name 2')
     })
 
@@ -220,7 +220,7 @@ describe('search', () => {
     test('should restrict results to 6 suggestions', async () => {
       getDistinctPayees.mockResolvedValue(Array(50).fill().map((_, i) => ({ payee_name: `payee name ${i}`, part_postcode: 'part postcode', town: 'town', county_council: 'county council' })))
       const data = await getSearchSuggestions('payee name')
-      expect(data.rows.length).toBe(6)
+      expect(data.rows).toHaveLength(6)
     })
 
     test('should not throw when searchString exceeds 32 characters', async () => {

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -103,9 +103,13 @@ describe('config', () => {
     expect(config.get('cdpEnvironment')).toBe('local')
   })
 
-  test('should return log enabled from environment variable', async () => {
+  test.each([
+    ['log.isEnabled'],
+    ['isSecureContextEnabled'],
+    ['isMetricsEnabled']
+  ])('should return %s as true from environment variable', async (key) => {
     const { config } = await import('../../src/config.js')
-    expect(config.get('log.isEnabled')).toBe(true)
+    expect(config.get(key)).toBe(true)
   })
 
   test('should default log enabled to true for non-test environments', async () => {
@@ -149,21 +153,11 @@ describe('config', () => {
     expect(config.get('httpProxy')).toBeNull()
   })
 
-  test('should return secure context enabled from environment variable', async () => {
-    const { config } = await import('../../src/config.js')
-    expect(config.get('isSecureContextEnabled')).toBe(true)
-  })
-
   test('should default secure context enabled to false for non-production environments', async () => {
     process.env.NODE_ENV = 'development'
     delete process.env.ENABLE_SECURE_CONTEXT
     const { config } = await import('../../src/config.js')
     expect(config.get('isSecureContextEnabled')).toBe(false)
-  })
-
-  test('should return metrics enabled from environment variable', async () => {
-    const { config } = await import('../../src/config.js')
-    expect(config.get('isMetricsEnabled')).toBe(true)
   })
 
   test('should default metrics enabled to false for non-production environments', async () => {

--- a/test/unit/data/payments.test.js
+++ b/test/unit/data/payments.test.js
@@ -37,25 +37,13 @@ describe('payments', () => {
       })
     })
 
-    test('should return headers', async () => {
+    test.each([
+      ['headers', '"payee_name","part_postcode","town","county_council","amount"'],
+      ['amount with no decimal formatted to 2dp', '"payee name","part postcode","town","county council","100.00"'],
+      ['amount with decimal formatted to 2dp', '"payee name","part postcode","town","county council","200.00"']
+    ])('should contain %s in csv output', async (_, expected) => {
       const data = await getPaymentsCsv({})
-      expect(data).toContain('"payee_name","part_postcode","town","county_council","amount"')
-    })
-
-    test('should return data as csv', async () => {
-      const data = await getPaymentsCsv({})
-      expect(data).toContain('"payee name","part postcode","town","county council","100.00"')
-      expect(data).toContain('"payee name","part postcode","town","county council","200.00"')
-    })
-
-    test('should format amount when value has no decimal', async () => {
-      const data = await getPaymentsCsv({})
-      expect(data).toContain('"payee name","part postcode","town","county council","100.00"')
-    })
-
-    test('should format amount when value has decimal', async () => {
-      const data = await getPaymentsCsv({})
-      expect(data).toContain('"payee name","part postcode","town","county council","200.00"')
+      expect(data).toContain(expected)
     })
 
     test('should format amount when value is zero', async () => {


### PR DESCRIPTION
## Summary
- Use `node:` prefix for stream import (S7772)
- Use `export...from` syntax for secure-context re-export (S7763)
- Replace generic `.length` assertions with `.toHaveLength()` (S5906)
- Parameterize repetitive tests with `test.each` (S5976)

## Test plan
- [x] All existing tests pass
- [x] No behavioural changes — style/clarity improvements only